### PR TITLE
Adds Menu Item Thumbnail

### DIFF
--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -311,4 +311,19 @@ class MenuItem extends Core implements CoreInterface {
 			return $this->__title;
 		}
 	}
+	
+	/**
+	 * Gets the post thumbnail image url
+	 * @example
+	 * ```twig
+	 * {% for item in menu.items %}
+	 *     <li><a href="{{ item.link }}"><img src="{{ item.thumbnail }}"/></a></li>
+	 * {% endfor %}
+	 * ```
+	 * @return string the public thumbnail url
+	 */
+	public function thumbnail() {
+		$postId = get_post_meta( $this->ID, '_menu_item_object_id', true );
+		return get_the_post_thumbnail_url($postId);
+	}
 }


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
When looping through menu items, you are not able to obtain the referenced post thumbnail image.


#### Solution
This adds a function to expose the post thumbnail url.


#### Impact
This change provides additional functionality.


#### Usage
When looping through a menu you can now use `{{item.thumbnail}}` to obtain the post thumbnail.